### PR TITLE
ci: fix release with merge commit

### DIFF
--- a/.changeset/commit.js
+++ b/.changeset/commit.js
@@ -11,11 +11,8 @@ const getAddMessage = async (changeset) => {
   return `docs(changeset): ${changeset.summary}\n\n${getSignedOffBy()}\n`
 }
 
-const getVersionMessage = async (releasePlan) => {
-  const publishableReleases = releasePlan.releases.filter((release) => release.type !== 'none')
-  const releasedVersion = publishableReleases[0].newVersion
-
-  return `chore(release): version ${releasedVersion}\n\n${getSignedOffBy()}\n`
+const getVersionMessage = async () => {
+  return `chore(release): new version\n\n${getSignedOffBy()}\n`
 }
 
 module.exports = {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
   release-stable:
     runs-on: ubuntu-20.04
     name: Release Stable
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -25,7 +27,7 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Create Release Pull Request
+      - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
@@ -42,7 +44,7 @@ jobs:
         run: echo "CURRENT_PACKAGE_VERSION=$(node -p "require('./packages/core/package.json').version")" >> $GITHUB_ENV
 
       - name: Create Github Release
-        if: "startsWith(github.event.head_commit.message, 'chore(release): new version')"
+        if: steps.changesets.outputs.published == 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ env.CURRENT_PACKAGE_VERSION }}
@@ -50,7 +52,8 @@ jobs:
   release-unstable:
     runs-on: ubuntu-20.04
     name: Release Unstable
-    if: "always() && github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(release): new version')"
+    needs: release-stable
+    if: always() && github.event_name == 'push' && needs.release-stable.outputs.published == 'false'
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
The script as used by Credo does not fully work as we allow merge commits in this repo, and that messes up the logic. Not checks whether a publish happened.